### PR TITLE
Fix weird formatting of `resize_to_layout!`

### DIFF
--- a/src/pages/blogposts/v0.16.md
+++ b/src/pages/blogposts/v0.16.md
@@ -133,7 +133,7 @@ DOM.div("by ", GitHub.owner("ffreyer"))
 
 ### using Cycled for single plots
 
-Plots can now be given attributes that pick a specific value from the current cycle using the `Cycled() struct, for example to choose the 3rd color from the current palette.
+Plots can now be given attributes that pick a specific value from the current cycle using the `Cycled()` struct, for example to choose the 3rd color from the current palette.
 
 ```julia
 using Statistics

--- a/src/pages/blogposts/v0.16.md
+++ b/src/pages/blogposts/v0.16.md
@@ -2,7 +2,7 @@
 
 The v0.16 release is one of the biggest Makie releases in quite some time, adding a new backend, big GLMakie improvements and lots of other small improvements.
 
-This blog-post will walk you through the main changes!
+This blog post will walk you through the main changes!
 
 ### RPRMakie
 
@@ -54,10 +54,11 @@ DOM.div("by ", GitHub.owner("ffreyer"))
 ### Scene refactor
 
 In ancient Makie, the `Scene` type was the main object to plot into.
-With the integration of MakieLayout, this changed and Figure/Axis became the main user facing types.
+With the integration of MakieLayout, this changed and `Figure`/`Axis` became the main user facing types.
 That turned `Scene` into a lower level type, but we never removed all the high-level constructs to control limits, axis etc.
 In this refactor, all higher level constructs got removed and turned the `Scene` type into a leaner scene graph type.
-These changes shouldn't be breaking for anyone working with the MakieLayout figure API. Breaking changes for the Scene API are explained in the [NEWS.md](https://github.com/JuliaPlots/Makie.jl/blob/master/NEWS.md):
+These changes shouldn't be breaking for anyone working with the `MakieLayout  figure API.
+Breaking changes for the Scene API are explained in the [NEWS.md](https://github.com/JuliaPlots/Makie.jl/blob/master/NEWS.md):
 
 >The Scene() constructor doesn't create any axes or limits anymore. All keywords like raw, show_axis have been removed. A scene now always works like it did when using the deprecated raw=true. All the high level functionality like showing an axis and adding a 3d camera has been moved to LScene.
 
@@ -72,7 +73,8 @@ DOM.div("by ", GitHub.owner("SimonDanisch"))
 
 ### Resize to layout
 
-Some figures with aspect ratio restrictions or fixed objects sizes use more or less than the allotted space. With the new command resize_to_layout!, a Figure can be adjusted so it uses exactly the size necessary for its current content.
+Some figures with aspect ratio restrictions or fixed objects sizes use more or less than the allotted space.
+With the new command `resize_to_layout!`, a Figure can be adjusted so it uses exactly the size necessary for its current content.
 
 ```julia
 using GLMakie
@@ -109,7 +111,7 @@ DOM.div("by ", GitHub.owner("jkrumbiegel"))
 ### OIT
 
 Order independent transparency has been on the wishlist for GLMakie for a very long time.
-It's still an approximation, so you may run into inaccurate transparency, but it should be much better then before:
+It's still an approximation, so you may run into inaccurate transparency, but it should be much better than before:
 
 ```julia
 fig = Figure()
@@ -131,7 +133,7 @@ DOM.div("by ", GitHub.owner("ffreyer"))
 
 ### using Cycled for single plots
 
-Plots can now be given attributes that pick a specific value from the current cycle using the Cycled() struct, for example to choose the 3rd color from the current palette.
+Plots can now be given attributes that pick a specific value from the current cycle using the `Cycled() struct, for example to choose the 3rd color from the current palette.
 
 ```julia
 using Statistics


### PR DESCRIPTION
Very pretty blog post! I only saw it today.

In the blog post, I noticed that it said resize _to_ layout! (without spaces). That mean missing backticks, so I fixed that in this PR. Since I had the document open I've also took the time to go through it and fix some minor typos and other missing backticks. Feel free to modify my PR to your liking.